### PR TITLE
Init all user details in firestore after signup successfully.

### DIFF
--- a/lib/src/utils/auth/auth.dart
+++ b/lib/src/utils/auth/auth.dart
@@ -1,10 +1,10 @@
 // import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:fitgap/src/utils/firestore/firestore.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 
 class AuthService {
   final userStream = FirebaseAuth.instance.authStateChanges();
-  final user = FirebaseAuth.instance.currentUser;
 
   //Email login is in login_page
 
@@ -30,6 +30,19 @@ class AuthService {
       idToken: gAuth.idToken,
     );
 
-    await FirebaseAuth.instance.signInWithCredential(credential);
+    //sign user in, obtain auth result
+    final UserCredential authResult =
+        await FirebaseAuth.instance.signInWithCredential(credential);
+
+    //add user detail to DB if new
+    final userEmail = authResult.user?.email ?? '';
+    final userExist = await FirestoreService().existUser(userEmail);
+
+    if (!userExist) {
+      FirestoreService().addUserDetails(
+        userEmail.split('@').first,
+        userEmail,
+      );
+    }
   }
 }

--- a/lib/src/utils/firestore/firestore.dart
+++ b/lib/src/utils/firestore/firestore.dart
@@ -29,9 +29,21 @@ class FirestoreService {
 
   //-------------------------------------------------------------
 
-  //CREATE: add user details
+  //CREATE: add new user details
   Future addUserDetails(String username, String email) async {
-    await _db.collection('users').add({'username': username, 'email': email});
+    await _db.collection('users').add(
+      {
+        'username': username,
+        'email': email,
+        'firstname': '',
+        'middlename': '',
+        'lastname': '',
+        'birthday': DateTime(2000, 1, 1),
+        'gender': 'Other',
+        'phone_number': '',
+        'address': '',
+      },
+    );
   }
 
   //CREATE: add event
@@ -80,4 +92,16 @@ class FirestoreService {
 
   //DELETE: delete events
   //DELETE: delete contacts
+
+  //UTIL: does user exist
+  Future<bool> existUser(String email) async {
+    userSnapshot =
+        await _db.collection('users').where('email', isEqualTo: email).get();
+
+    if (userSnapshot.docs.isNotEmpty) {
+      return true;
+    } else {
+      return false;
+    }
+  }
 }


### PR DESCRIPTION
initialized all fields in firestore when user signs up.
Current problem: signup with email first then google will makes logging in with email unavailable.
Keyword: Verify email
See: [Firebase Auth link provider Google sign in issue](https://stackoverflow.com/questions/66452341/firebase-auth-link-provider-google-sign-in-issue)